### PR TITLE
Implement breadcrumbs in category show page

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,12 +1,21 @@
 class CategoriesController < ApplicationController
+
+  before_action :set_category, only: [:show]
+
   def new
     @middlecategory = Category.find(params[:category_id]).children
     respond_to do |form|
       form.json{@middlecategory}
     end
   end
+
   def show
-    @category = Category.find(params[:id])
     @products = @category.find_products(@category)
+  end
+
+  private
+
+  def set_category
+    @category = CategoryDecorator.decorate(Category.find(params[:id]))
   end
 end

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -1,0 +1,3 @@
+class CategoryDecorator < Draper::Decorator
+  delegate_all
+end

--- a/app/decorators/category_decorator.rb
+++ b/app/decorators/category_decorator.rb
@@ -1,3 +1,13 @@
 class CategoryDecorator < Draper::Decorator
   delegate_all
+
+  def check_for_category_hirearchy
+    if self.ancestry == nil
+      :first_category
+    elsif !self.ancestry.match(/\//)
+      :second_category
+    else
+      :third_category
+    end
+  end
 end

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,4 +1,7 @@
 = render 'layouts/header'
+- breadcrumb @category.check_for_category_hirearchy, @category
+.breadcrumbs
+  = breadcrumbs separator: "#{fa_icon("angle-right", class: "breadcrumbs__seperator")} ", class: "breadcrumbs__container"
 %main.category-items-container
   %h1.category-items-container__header
     = @category.name

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -47,6 +47,12 @@ crumb :user_shipping_info do
   link "発送元・お届け先住所変更"
   parent :user, current_user
 end
+
+crumb :category_list do
+  link "カテゴリ一覧"
+  parent :root
+end
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -53,6 +53,21 @@ crumb :category_list do
   parent :root
 end
 
+crumb :first_category do |first_category|
+  link first_category.name, category_path(first_category)
+  parent :category_list
+end
+
+crumb :second_category do |second_category|
+  link second_category.name, category_path(second_category)
+  parent :first_category, second_category.parent
+end
+
+crumb :third_category do |third_category|
+  link third_category.name, category_path(third_category)
+  parent :second_category, third_category.parent
+end
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end


### PR DESCRIPTION
# WHAT
パンくず機能をカテゴリ一覧以下の各カテゴリのページに作成
decoratorファイルにビューで使用するメソッドを定義することにより、ビューをクリーンに保つ

# WHY
パンくず機能は必須であるため